### PR TITLE
Add implementation

### DIFF
--- a/GemFile
+++ b/GemFile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'random-word', '~> 2.1'
+gem 'rspec'
+gem 'rubocop', source: 'https://rubygems.org'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,44 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.0)
+    diff-lcs (1.3)
+    jaro_winkler (1.5.4)
+    parallel (1.19.0)
+    parser (2.6.5.0)
+      ast (~> 2.4.0)
+    rainbow (3.0.0)
+    random-word (2.1.1)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.0)
+      rspec-support (~> 3.9.0)
+    rspec-expectations (3.9.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.0)
+    rubocop (0.76.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.6)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    ruby-progressbar (1.10.1)
+    unicode-display_width (1.6.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  random-word (~> 2.1)
+  rspec
+  rubocop!
+
+BUNDLED WITH
+   2.0.2

--- a/hangman.rb
+++ b/hangman.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'random-word'
+
+class Hangman
+  @word = ''
+  @guessedChars = []
+
+  def initialize
+    @word = RandomWord.nouns.next
+    @unmaskedWord = mask
+    @attempts = 6
+  end
+
+  def word
+    @word
+  end
+
+  def mask
+    @word.chars.map { |c| '_'}.to_s
+  end
+
+  def unmaskedWord
+    @unmaskedWord
+  end
+
+  def attempts
+    @attempts
+  end
+
+  def gameOver
+    return (@unmaskedWord.count('_').zero? || @attempts.zero?)
+  end
+
+  def play(char)
+    if char.scan(/[a-zA-Z]+/)
+      if @word.include?(char)
+        (@guessedChars ||= []) << char
+        @guessedChars << char unless @guessedChars.any? { |c| c.include?(char) }
+        @unmaskedWord = unmask(char)
+      else
+        @attempts =+ 1
+      end
+    end
+  end
+
+  private
+
+  def unmask(char)
+    offset = 0
+    while not @word.index(char, offset).nil?
+      @unmaskedWord.chars[@word.index(char)] = char
+      offset = @word.index(char)
+    end
+    @unmaskedWord
+  end
+end

--- a/spec/hangman_spec.rb
+++ b/spec/hangman_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require './hangman'
+
+RSpec.describe Hangman do
+  describe ".initialize" do
+    let!(:subject) { described_class.new }
+    let!(:maskedWord) { subject.word.chars.map { |c| '_ '}.to_s }
+    context "when the game starts" do
+      it "generates a random word" do
+        expect(subject.word).not_to eq('')
+      end
+      it "displays the word as dashes" do
+        expect(subject.mask).to eq(maskedWord)
+      end
+      it "sets the remaining attempts to six" do
+        expect(subject.attempts).to eq(6)
+      end
+    end
+  end
+  describe ".play" do
+    context "when the game is not over" do
+      context "and the user guesses a character in the word" do
+          context "when there is only one character to reveal" do
+            it "reveals the character(s) in the word" do
+            end
+            it "signifies game over" do
+            end
+          end
+          context "when there are more than one character to reveal" do
+            it "reveals the character in the word" do
+            end
+          end
+      end
+      context "and the user guesses a character not in the word" do
+        context "when there are remaining attempts" do
+          it "decrements the remaining attempts" do
+          end
+        end
+        context "when there are no remaining attempts" do
+          it "signifies game over" do
+          end
+        end
+      end
+      context "and the user guesses a revealed character" do
+        it "lets play continue" do
+        end
+      end
+      context "and the user guesses a non-character" do
+        it "lets play continue" do
+        end
+      end
+    end
+  end
+end

--- a/spec/hangman_spec.rb
+++ b/spec/hangman_spec.rb
@@ -5,7 +5,7 @@ require './hangman'
 RSpec.describe Hangman do
   describe ".initialize" do
     let!(:subject) { described_class.new }
-    let!(:maskedWord) { subject.word.chars.map { |c| '_ '}.to_s }
+    let!(:maskedWord) { subject.word.chars.map { |c| '_'}.to_s }
     context "when the game starts" do
       it "generates a random word" do
         expect(subject.word).not_to eq('')
@@ -21,12 +21,18 @@ RSpec.describe Hangman do
   describe ".play" do
     context "when the game is not over" do
       context "and the user guesses a character in the word" do
-          context "when there is only one character to reveal" do
-            it "reveals the character(s) in the word" do
-            end
-            it "signifies game over" do
-            end
+        let!(:guessedChar) { subject.word[0] }
+        let!(:maskedWord) { subject.word.chars.map { |c| c == guessedChar ? c : '_ ' }.to_s }
+        it "reveals the character(s) in the word" do
+          # subject.play(guessedChar)
+          # puts maskedWord
+          # puts subject.unmaskedWord
+          #expect(subject.unmaskedWord).to eq(maskedWord)
+        end
+        context "when there is only one character to reveal" do
+          it "signifies game over" do
           end
+        end
           context "when there are more than one character to reveal" do
             it "reveals the character in the word" do
             end


### PR DESCRIPTION
### Context

Without using the brief, I devised the rules of the game as specified in the test spec

```
Hangman
  .initialize
    when the game starts
      generates a random word
      displays the word as dashes
      sets the remaining attempts to six
  .play
    when the game is not over
      and the user guesses a character in the word
        reveals the character(s) in the word
        when there is only one character to reveal
          signifies game over
        when there are more than one character to reveal
          reveals the character in the word
      and the user guesses a character not in the word
        when there are remaining attempts
          decrements the remaining attempts
        when there are no remaining attempts
          signifies game over
      and the user guesses a revealed character
        lets play continue
      and the user guesses a non-character
        lets play continue
```

### Changes

- add failing tests
- add implementation (made a start!)

### Discussion
I am happy for the `wip` code to be reviewed, however I would like to abandon this path in favour of following the brief as I don't want to have to think about what I am designing.  I can focus my attention on the code to implement.
